### PR TITLE
Issue #43: remove deprecated __autoload to support PHP 7.2.

### DIFF
--- a/Library/Bootstrap.php
+++ b/Library/Bootstrap.php
@@ -17,10 +17,11 @@ foreach ($_REQUEST as $index => $data) {
 }
 
 # Autoloader
-function __autoload($class)
+function autoloader($class)
 {
     require_once str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
 }
+spl_autoload_register('autoloader');
 
 # Loading ini file
 $_ini = Library_Configuration_Loader::singleton();

--- a/Library/Data/Analysis.php
+++ b/Library/Data/Analysis.php
@@ -23,14 +23,14 @@
  */
 class Library_Data_Analysis
 {
-    const NON_ADDITIVE = [
+    private static $_non_additive = array(
         'libevent',
         'pid',
         'pointer_size',
         'time',
         'uptime',
         'version',
-    ];
+    );
 
     /**
      * Merge two arrays of stats from Command_XX::stats()
@@ -51,7 +51,7 @@ class Library_Data_Analysis
 
         # Merging Stats
         foreach ($stats as $key => $value) {
-            if (! isset($array[$key]) || in_array($key, static::NON_ADDITIVE)) {
+            if (! isset($array[$key]) || in_array($key, self::$_non_additive)) {
                 $array[$key] = $value;
             } else {
                 $array[$key] += $value;
@@ -79,7 +79,7 @@ class Library_Data_Analysis
 
         # Diff for each key
         foreach ($stats as $key => $value) {
-            if (isset($array[$key]) && ! in_array($key, static::NON_ADDITIVE)) {
+            if (isset($array[$key]) && ! in_array($key, self::$_non_additive)) {
                 $stats[$key] = $value - $array[$key];
             }
         }


### PR DESCRIPTION
Replace the use of deprecated __autoload by spl_autoload_register, which has been recommended since PHP 5.1.0 in 2005.